### PR TITLE
[Autopilot] approval for rule kube-system/volume-resize-pvc-e19f1f38-4d72-4a73-bbfe-dc0a5673be44 rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-e19f1f38-4d72-4a73-bbfe-dc0a5673be44.yaml
+++ b/workloads/volume-resize-pvc-e19f1f38-4d72-4a73-bbfe-dc0a5673be44.yaml
@@ -1,0 +1,40 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-e19f1f38-4d72-4a73-bbfe-dc0a5673be44
+    rule: volume-resize
+  managedFields:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:object: {}
+          f:rule: {}
+      f:spec:
+        .: {}
+        f:actions: {}
+        f:approvalState: {}
+      f:status: {}
+    manager: ___4go_build_main_go
+    operation: Update
+    time: "2022-10-19T23:45:49Z"
+  name: volume-resize-pvc-e19f1f38-4d72-4a73-bbfe-dc0a5673be44
+  namespace: kube-system
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 20Gi
+      scalepercentage: "150"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:20Gi scalepercentage:150]

#### ExpectedResult

PVC will resize from 10Gi to 20Gi
 
#### What objects will get affected

- PersistentVolumeClaim kube-system/pgbench-4 (pvc-e19f1f38-4d72-4a73-bbfe-dc0a5673be44)     

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
